### PR TITLE
Bounds.from_point_and_radius returns an invalid bounds if the bounds crosses a pole or itself

### DIFF
--- a/lib/geokit/mappable.rb
+++ b/lib/geokit/mappable.rb
@@ -92,7 +92,17 @@ module Geokit
         end_lng=lng+Math.atan2(Math.sin(heading)*Math.sin(distance/radius)*Math.cos(lat),
                                Math.cos(distance/radius)-Math.sin(lat)*Math.sin(end_lat))
 
-        LatLng.new(rad2deg(end_lat),rad2deg(end_lng))
+        new_point = LatLng.new(rad2deg(end_lat),rad2deg(end_lng))
+
+        # wrap around to a valid degree in range -180 -> 180
+        while (new_point.lng < 180)
+         new_point.lng += 360
+        end
+        while (new_point.lng > 180)
+         new_point.lng -= 360
+        end
+
+        new_point
       end
 
       # Returns the midpoint, given two points. Returns a LatLng. 
@@ -446,6 +456,7 @@ module Geokit
   # Bounds represents a rectangular bounds, defined by the SW and NE corners
   class Bounds
     MAX_LATITUDE = 90 - 0.0000000000000000001
+    MAX_LONGITUDE = 180
 
     # sw and ne are LatLng objects
     attr_accessor :sw, :ne
@@ -531,12 +542,12 @@ module Geokit
         # circumference is 2 x radius x PI
         max_distance = point.class.units_sphere_multiplier(options[:units] || Geokit::default_units) * Math::PI
         p90 = if (radius > max_distance)
-          point.endpoint(90,max_distance,options)
+          LatLng.new(point.lat,MAX_LONGITUDE)
         else
           point.endpoint(90,radius,options)
         end
         p270 = if (radius > max_distance)
-          point.endpoint(270,max_distance,options)
+          LatLng.new(point.lat,-MAX_LONGITUDE)
         else
           point.endpoint(270,radius,options)
         end

--- a/test/test_bounds.rb
+++ b/test/test_bounds.rb
@@ -72,15 +72,25 @@ class BoundsTest < Test::Unit::TestCase #:nodoc: all
   end
 
   def test_from_point_and_radius
-    bounds=Geokit::Bounds.from_point_and_radius([0, 0],100)
+    bounds=Geokit::Bounds.from_point_and_radius([0, 0], 100)
     assert_in_delta -1.445, bounds.sw.lat, 0.005
     assert_in_delta -1.445, bounds.sw.lng, 0.005
   end
 
-  def test_from_point_and_radius_wrapping
-    bounds=Geokit::Bounds.from_point_and_radius([0, 0],50000)
+  def test_from_point_and_radius_greater_than_circumference
+    bounds=Geokit::Bounds.from_point_and_radius([0,45], 50000)
     assert_in_delta 90, bounds.ne.lat, 0.005
     assert_in_delta -180, bounds.sw.lng, 0.005
+    assert_in_delta 180, bounds.ne.lng, 0.005
+  end
+
+  def test_from_point_and_radius_causes_wrapping
+    bounds=Geokit::Bounds.from_point_and_radius([0,90], 9000)
+    assert_in_delta -139.887, bounds.ne.lng, 0.005 # 220.113 before wrapping
+    assert_in_delta -40.113, bounds.sw.lng, 0.005
+    bounds=Geokit::Bounds.from_point_and_radius([0,-90], 9000)
+    assert_in_delta 40.113, bounds.ne.lng, 0.005 # -220.113 before wrapping
+    assert_in_delta 139.887, bounds.sw.lng, 0.005
   end
 
   def test_bounds_to_span

--- a/test/test_bounds.rb
+++ b/test/test_bounds.rb
@@ -70,7 +70,19 @@ class BoundsTest < Test::Unit::TestCase #:nodoc: all
     assert bounds.contains?(inside)
     assert !bounds.contains?(outside)
   end
-  
+
+  def test_from_point_and_radius
+    bounds=Geokit::Bounds.from_point_and_radius([0, 0],100)
+    assert_in_delta -1.445, bounds.sw.lat, 0.005
+    assert_in_delta -1.445, bounds.sw.lng, 0.005
+  end
+
+  def test_from_point_and_radius_wrapping
+    bounds=Geokit::Bounds.from_point_and_radius([0, 0],50000)
+    assert_in_delta 90, bounds.ne.lat, 0.005
+    assert_in_delta -180, bounds.sw.lng, 0.005
+  end
+
   def test_bounds_to_span
     sw = Geokit::LatLng.new(32, -96)
     ne = Geokit::LatLng.new(40, -70)


### PR DESCRIPTION
This fix addresses an issue where the bounds was frequently cross one of the poles, and in rare circumstances where the radius was so large the bounds needed to encompass the earth, in the current version the bounds returned are incorrect.
